### PR TITLE
v1.8.0 release

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -35,4 +35,6 @@
   // "yaml.schemas": {
   //   "https://demotime.show/demo-time.schema.json": ".demo/*"
   // }
+  "chat.tools.autoApprove": true,
+"chat.agent.maxRequests": 100
 }

--- a/src/content/docs/actions/copilot.mdx
+++ b/src/content/docs/actions/copilot.mdx
@@ -1,7 +1,7 @@
 ---
 title: GitHub Copilot actions
 description: Actions for integrating GitHub Copilot in Demo Time
-lastmod: 2025-07-17T16:17:13.761Z
+lastmod: 2025-08-02T15:59:43.607Z
 ---
 
 import { Aside, Tabs, TabItem } from '@astrojs/starlight/components';
@@ -61,12 +61,16 @@ action: newCopilotChat
 
 ## Ask a question in Copilot chat
 
-To ask a question, use the `askCopilotChat` action with a `message` property.
+To ask a question, use the `askCopilotChat` action. The `message` property is optional; if omitted, the chat will open without sending a message.
 
 <Tabs syncKey="copilot-ask-chat">
 <TabItem label="JSON">
 
 ```json
+{
+  "action": "askCopilotChat"
+}
+
 {
   "action": "askCopilotChat",
   "message": "Write a function that returns 'Hello from Demo Time'."
@@ -78,6 +82,10 @@ To ask a question, use the `askCopilotChat` action with a `message` property.
 
 ```yaml
 action: askCopilotChat
+```
+
+```yaml
+action: askCopilotChat
 message: "Write a function that returns 'Hello from Demo Time'."
 ```
 
@@ -86,12 +94,16 @@ message: "Write a function that returns 'Hello from Demo Time'."
 
 ## Start an edit chat with Copilot
 
-To start an edit chat, use the `editCopilotChat` action with a `message` property.
+To start an edit chat, use the `editCopilotChat` action. The `message` property is optional.
 
 <Tabs syncKey="copilot-edit-chat">
 <TabItem label="JSON">
 
 ```json
+{
+  "action": "editCopilotChat"
+}
+
 {
   "action": "editCopilotChat",
   "message": "Write a function that returns 'Hello from Demo Time'."
@@ -103,6 +115,10 @@ To start an edit chat, use the `editCopilotChat` action with a `message` propert
 
 ```yaml
 action: editCopilotChat
+```
+
+```yaml
+action: editCopilotChat
 message: "Write a function that returns 'Hello from Demo Time'."
 ```
 
@@ -111,12 +127,16 @@ message: "Write a function that returns 'Hello from Demo Time'."
 
 ## Start an agent chat with Copilot
 
-To start an agent chat, use the `agentCopilotChat` action with a `message` property.
+To start an agent chat, use the `agentCopilotChat` action. The `message` property is optional.
 
 <Tabs syncKey="copilot-agent-chat">
 <TabItem label="JSON">
 
 ```json
+{
+  "action": "agentCopilotChat"
+}
+
 {
   "action": "agentCopilotChat",
   "message": "Write a function that returns 'Hello from Demo Time'."
@@ -125,6 +145,10 @@ To start an agent chat, use the `agentCopilotChat` action with a `message` prope
 
 </TabItem>
 <TabItem label="YAML">
+
+```yaml
+action: agentCopilotChat
+```
 
 ```yaml
 action: agentCopilotChat

--- a/src/content/docs/actions/snippet.mdx
+++ b/src/content/docs/actions/snippet.mdx
@@ -1,7 +1,7 @@
 ---
 title: Snippet actions
 description: Snippets can be used when you have steps that you want to reuse in multiple demos.
-lastmod: 2025-07-12T13:58:47.064Z
+lastmod: 2025-08-02T16:00:27.344Z
 ---
 
 import { Aside, Tabs, TabItem } from '@astrojs/starlight/components';
@@ -77,7 +77,6 @@ The contents of this file could look like this:
 
 ```yaml
 - action: unselect
-  path: "{MAIN_FILE}"
 - action: insert
   path: "{MAIN_FILE}"
   contentPath: "{CONTENT_PATH}"

--- a/src/content/docs/actions/terminal.mdx
+++ b/src/content/docs/actions/terminal.mdx
@@ -1,7 +1,7 @@
 ---
 title: Terminal actions
 description: Perform terminal actions in your demos like running commands, clearing the terminal, and more.
-lastmod: 2025-07-11T13:15:07.409Z
+lastmod: 2025-08-02T16:01:30.079Z
 ---
 
 import { Aside, Code, Tabs, TabItem } from '@astrojs/starlight/components';

--- a/src/content/docs/references/api.mdx
+++ b/src/content/docs/references/api.mdx
@@ -1,7 +1,7 @@
 ---
 title: API
 description: Demo Time provides an API to control the extension programmatically.
-lastmod: 2025-07-04T14:53:50.807Z
+lastmod: 2025-08-02T15:56:10.675Z
 tableOfContents: false
 ---
 
@@ -20,6 +20,10 @@ API URL: `http://localhost:3710/api/next`
 Once enabled, it shows the API and its port number in the status bar of Visual Studio Code.
 
 <Image class="mx-auto" src={apiPortImg} alt="API enabled with port 3710" width="400" />
+
+<Aside type="tip">
+  When enabled, you can click on the status bar API or open the site in your browser to see the API documentation. Example: `http://localhost:3710`
+</Aside>
 
 ## API endpoints
 
@@ -53,7 +57,7 @@ You can call this endpoint via a `GET` or `POST` request.
 - Method: `POST`
 - Body:
 
-  ```json
+  ```json title="API Body"
   {
     "id": "<step id>",
     "bringToFront": "<bring the Visual Studio Code window to the front (optional) - default is false>"
@@ -62,3 +66,38 @@ You can call this endpoint via a `GET` or `POST` request.
 
 - Headers:
   - `Content-Type: application/json`
+
+### `/api/demos`
+
+Returns all demo files, the next demo, and the currently executing demo file.
+
+- Method: `GET`
+
+#### Response
+
+```json title="Demos API Response"
+{
+  "demoFiles": [
+    {
+      "filePath": "/absolute/path/to/demo.json",
+      "demos": [
+        { "id": "demo1", "title": "Demo 1" },
+        { "id": "demo2", "title": "Demo 2" }
+      ]
+    }
+  ],
+  "nextDemo": { "id": "demo2", "title": "Demo 2" },
+  "currentDemoFile": {
+    "filePath": "/absolute/path/to/demo.json",
+    "demo": [
+      { "id": "demo1", "title": "Demo 1" }
+    ]
+  }
+}
+```
+
+#### Description
+
+- `demoFiles`: Array of demo files, each with its file path and contained demos (id and title).
+- `nextDemo`: The next demo to be executed (id and title), if available.
+- `currentDemoFile`: The currently executing demo file, with its file path and demos.

--- a/src/content/docs/releases/1.8.0.md
+++ b/src/content/docs/releases/1.8.0.md
@@ -1,0 +1,30 @@
+---
+title: v1.8.0
+description: Release notes for version 1.8.0 of the Demo Time extension, including new features, improvements, and bug fixes.
+date: 2025-08-02
+version: 1.8.0
+slug: 1.8.0
+lastmod: 2025-08-02T16:12:01.734Z
+---
+
+## Highlights
+
+- **Improved slide loading** when switching between demo and slides ([#199](https://github.com/estruyf/vscode-demo-time/issues/199)). Switching between your scripted demo and slides is now much smoother, making live presentations more reliable and seamless.
+
+- **New `openTerminal` action** ([#204](https://github.com/estruyf/vscode-demo-time/issues/204)). You can now open a terminal as part of your demo steps, making it easier to automate and script terminal-based workflows. Learn more in the [actions reference](/actions/terminal).
+
+- **`hacker-typer` typing mode** ([#205](https://github.com/estruyf/vscode-demo-time/issues/205)). Add drama to your demos! The new `hacker-typer` mode for `insert`, `replace`, and `patch` actions simulates fast, cinematic typing. See [text actions documentation](/actions/text#typing-modes) for usage and examples.
+
+- **GitHub Copilot chat improvements** ([#207](https://github.com/estruyf/vscode-demo-time/issues/207)). The `message` property is now optional for Copilot chat actions, making it easier to open a chat panel or start a session without sending an initial message. See [Copilot actions documentation](/actions/copilot).
+
+- **Smarter JSON schema and intellisense** ([#208](https://github.com/estruyf/vscode-demo-time/issues/208)). The JSON schema has been refactored to provide intellisense per action, showing which properties are required and which are optional. This makes authoring demo files in VS Code much easier.
+
+- **`path` property is not required anymore for `unselect`** ([#209](https://github.com/estruyf/vscode-demo-time/issues/209)). You no longer need to specify a path when unselecting text, simplifying your demo steps. See [text actions documentation](/actions/text#unselect-text).
+
+- **`description` property is now optional on the demo root** ([#211](https://github.com/estruyf/vscode-demo-time/issues/211)). This gives you more flexibility when structuring your demo files.
+
+- **Fixes and improvements**:
+  - Fixed encoding issue with ampersands in the `dt-list` component ([#212](https://github.com/estruyf/vscode-demo-time/issues/212)).
+  - Fixed highlighting of whole lines when using line number and character positioning ([#217](https://github.com/estruyf/vscode-demo-time/issues/217)). See [highlighting tips](/tips/highlighting).
+
+- **New `/api/demos` endpoint** ([#218](https://github.com/estruyf/vscode-demo-time/issues/218)). Retrieve the list of all demos in your workspace programmatically. See the [API documentation](/references/api).


### PR DESCRIPTION
- [#199](https://github.com/estruyf/vscode-demo-time/issues/199): Improve loading the slides when
  switching between demo and slides
- [#204](https://github.com/estruyf/vscode-demo-time/issues/204): Added the `openTerminal` action to
  open a the terminal
- [#205](https://github.com/estruyf/vscode-demo-time/issues/205): Added the `hacker-typer` typing mode to the `insert`, `replace`, and `patch` actions
- [#207](https://github.com/estruyf/vscode-demo-time/issues/207): Made the `message` property
  optional for the GitHub Copilot chat actions
- [#208](https://github.com/estruyf/vscode-demo-time/issues/208): The JSON schema has been
  refactored to have intellisense per action on which properties are required and optional
- [#209](https://github.com/estruyf/vscode-demo-time/issues/209): The `path` property is not
  required anymore for the `unselect` action
- [#211](https://github.com/estruyf/vscode-demo-time/issues/211): Make the description property
  optional on the demo root
- [#212](https://github.com/estruyf/vscode-demo-time/issues/212): Fix encoding issue with ampersands
  in the `dt-list` component
- [#217](https://github.com/estruyf/vscode-demo-time/issues/217): Fix highlighting whole line when line number and 
  character positioning is used
- [#218](https://github.com/estruyf/vscode-demo-time/issues/218): Added a new `/api/demos` endpoint to 
  retrieve the list of demos in the workspace